### PR TITLE
add push to action input

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -26,6 +26,9 @@ inputs:
   input:
     description: "List of image-build inputs (-s)"
     required: false
+  push:
+    description: "True/False Push to docker registry"
+    required: false
   debug:
     description: "Debug output"
     required: false


### PR DESCRIPTION
Currently its not possible to push to a docker registry.
This PR will add this option.